### PR TITLE
Fix issue where resized images lose column alignment

### DIFF
--- a/src/css/_content.scss
+++ b/src/css/_content.scss
@@ -50,8 +50,9 @@
 .entry-content > *,
 .entry-summary > *,
 .not-found > * {
-	margin-right: auto;
-	margin-left: auto;
+	// Override questionable margins on elements like .wp-block-image.is-resized
+	margin-right: auto !important;
+	margin-left: auto !important;
 	padding-right: 1.5rem;
 	padding-left: 1.5rem;
 	max-width: $content-width;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/442115/72276957-0ed51680-35ff-11ea-8be3-794e8d877b86.png)
Resolves this by stomping on the `margin-left: 0` rule from g'berg that's causing the fuss